### PR TITLE
python-blosc 1.10.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,6 @@ requirements:
   host:
     - python
     - pip
-    - blosc
     - scikit-build
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,12 +13,14 @@ source:
 
 build:
   number: 0
-  # There is not available a dependency scikit-build on win32
+  # There is no available dependency scikit-build on win32
   skip: True  # [win32]
   skip: True  # [py<36]
   script:
     - export DISABLE_BLOSC_SSE2=1  # [ppc64le]
     - export DISABLE_BLOSC_AVX2=1  # [ppc64le]
+    - export USE_SYSTEM_BLOSC=1    # [unix]
+    - set USE_SYSTEM_BLOSC=1       # [win]
     - {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -30,6 +32,7 @@ requirements:
     - ninja
   host:
     - python
+    - blosc
     - pip
     - scikit-build
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,10 @@ source:
 
 build:
   number: 0
+  # There is not available a dependency scikit-build on win32
+  skip: True  # [win32]
+  skip: True  # [py<36]
   script:
-    # We can't use CMAKE_GENERATOR implicitly via conda_build_config.yaml, yet,
-    # due to https://github.com/AnacondaRecipes/aggregate/pull/182
-    - set "CMAKE_GENERATOR={{ CMAKE_GENERATOR }}"  # [win]
     - export DISABLE_BLOSC_SSE2=1  # [ppc64le]
     - export DISABLE_BLOSC_AVX2=1  # [ppc64le]
     - {{ PYTHON }} -m pip install . -vv
@@ -27,31 +27,34 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make  # [unix]
+    - ninja
   host:
     - python
-    - setuptools
-    - blosc
     - pip
-    - wheel
+    - blosc
     - scikit-build
+    - setuptools
+    - wheel
   run:
     - python
-    - blosc
-    - numpy
-    - psutil
+
 test:
   imports:
     - blosc
+  requires:
+    - numpy
+    - psutil
+    - pip
   commands:
+    - pip check
     - python -c "import blosc; blosc.print_versions()"
     - python -c "import blosc; blosc.test()"
 
 about:
   home: https://github.com/Blosc/python-blosc
-  license_family: Apache
-  license: Apache 2.0
-  license_file: LICENSES/PYTHON-BLOSC.txt
-  summary: 'A Python wrapper for the extremely fast Blosc compression library'
+  license_family: BSD
+  license: BSD-3-Clause
+  summary: A Python wrapper for the extremely fast Blosc compression library
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "blosc" %}
-{% set version = "1.10.2" %}
-{% set sha256 = "eeba922f52becd697dc5cfcee8d01a03ba9597a54ce91fdacd9998492acbed9b" %}
+{% set version = "1.10.6" %}
+{% set sha256 = "55d9d57b85d6eeec010c6c399f2820f96f566dccbc6ddfeefb60501f8e10b548" %}
 
 package:
   name: python-{{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,10 +50,12 @@ test:
     - python -c "import blosc; blosc.test()"
 
 about:
-  home: https://github.com/Blosc/python-blosc
+  home: http://python-blosc.blosc.org/
   license_family: BSD
   license: BSD-3-Clause
   summary: A Python wrapper for the extremely fast Blosc compression library
+  dev_url: https://github.com/Blosc/python-blosc
+  doc_url: http://python-blosc.blosc.org/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   # There is no available dependency scikit-build on win32
-  skip: True  # [win32]
+  skip: True  # [win32 or s390x]
   skip: True  # [py<36]
   script:
     - export DISABLE_BLOSC_SSE2=1  # [ppc64le]


### PR DESCRIPTION
Version change: bump version number from 1.10.2 to 1.10.6
Requirements from conda-forge: https://github.com/conda-forge/python-blosc-feedstock/blob/master/recipe/meta.yaml
Bug Tracker: new open issues https://github.com/Blosc/python-blosc/issues
Github releases:  https://github.com/Blosc/python-blosc/blob/v1.10.6/RELEASE_NOTES.rst
Upstream setup.py:  https://github.com/Blosc/python-blosc/blob/v1.10.6/setup.py
Upstream pyproject.toml:  https://github.com/Blosc/python-blosc/blob/v1.10.6/pyproject.toml

Actions:
1.   Skip `win32`. There is no available dependency `scikit-build` on win32
2. Skip `py<36`
3. Add `ninja` to build
4. Remove `blosc` from host and run
5. Move `numpy` and `psutil `to test/requires
6. Add `pip check`
7. Update home url and add doc url
8. Build using `USE_SYSTEM_BLOSC=1`
9. Skip `s390x`

Result:
- all-succeeded
